### PR TITLE
switched hubot-youtube back to upstream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "hubot-irc": "github:davidscholberg/hubot-irc#flood-protection-fix",
         "hubot-scripts": "^2.17.2",
         "hubot-shell": "^1.0.2",
-        "hubot-youtube": "github:davidscholberg/hubot-youtube#add-title-display-option"
+        "hubot-youtube": "^1.2.0"
       },
       "devDependencies": {
         "@types/hubot": "^3.3.0",
@@ -1306,14 +1306,14 @@
       "integrity": "sha1-xSeV2tPk0uHTfDyrSDjb97NIaVw="
     },
     "node_modules/hubot-youtube": {
-      "version": "1.1.0",
-      "resolved": "git+ssh://git@github.com/davidscholberg/hubot-youtube.git#fe62797f088a2ac813d4ec0a9618a853cb339c47",
-      "license": "MIT",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hubot-youtube/-/hubot-youtube-1.2.0.tgz",
+      "integrity": "sha512-xp5vHxjryk0oHoRSwmvts8SzKM+0SvqpG0bDLwQMZXMSVfS49P6Lo9qwCVQb7qq4zEeIRIVAnCvmBulWAyssBQ==",
       "dependencies": {
         "he": "^1.2.0"
       },
       "peerDependencies": {
-        "hubot": ">=2 <10 || 0.0.0-development"
+        "hubot": "^3"
       }
     },
     "node_modules/iconv": {
@@ -3328,8 +3328,9 @@
       "integrity": "sha1-xSeV2tPk0uHTfDyrSDjb97NIaVw="
     },
     "hubot-youtube": {
-      "version": "git+ssh://git@github.com/davidscholberg/hubot-youtube.git#fe62797f088a2ac813d4ec0a9618a853cb339c47",
-      "from": "hubot-youtube@github:davidscholberg/hubot-youtube#add-title-display-option",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hubot-youtube/-/hubot-youtube-1.2.0.tgz",
+      "integrity": "sha512-xp5vHxjryk0oHoRSwmvts8SzKM+0SvqpG0bDLwQMZXMSVfS49P6Lo9qwCVQb7qq4zEeIRIVAnCvmBulWAyssBQ==",
       "requires": {
         "he": "^1.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hubot-irc": "github:davidscholberg/hubot-irc#flood-protection-fix",
     "hubot-scripts": "^2.17.2",
     "hubot-shell": "^1.0.2",
-    "hubot-youtube": "github:davidscholberg/hubot-youtube#add-title-display-option"
+    "hubot-youtube": "^1.2.0"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
We can switch back to upstream now that
https://github.com/hubot-scripts/hubot-youtube/pull/16 has been merged
and pushed to npm.