### PR TITLE
removed date from quote output

### DIFF
--- a/scripts/quote.js
+++ b/scripts/quote.js
@@ -75,8 +75,7 @@ module.exports = async (robot) => {
           }
           response.send(outputText);
         } else {
-          const dateString = quote.date.toISOString().replace('T', ' ').substr(0, 19);
-          response.send(`${dateString} <${quote.user}> ${quote.text}`);
+          response.send(`<${quote.user}> ${quote.text}`);
         }
       } catch (error) {
         console.error(`error retrieving quote from database: ${error}`);


### PR DESCRIPTION
This was done mostly because old data being imported into the new schema
has incorrect dates (the dates are the grab dates rather than the quote
dates), and it is currently not worth the effort to fix it.